### PR TITLE
Option to generate sonarqube compatible report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ dmypy.json
 .pyre/
 .tox-semgrep
 .vscode
+.idea
 
 # mac
 .DS_Store

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -91,10 +91,6 @@ def sonarqube_output(outfile, scan_results):
         issue = get_sonarqube_issue(v)
         issue['ruleId'] = k
         sonarqube_issues.append(issue)
-    for k, v in scan_results['templates'].items():
-        issue = get_sonarqube_issue(v)
-        issue['ruleId'] = k
-        sonarqube_issues.append(issue)
     sonarqube_report = {
         'issues': sonarqube_issues,
     }

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -91,6 +91,10 @@ def sonarqube_output(outfile, scan_results):
         issue = get_sonarqube_issue(v)
         issue['ruleId'] = k
         sonarqube_issues.append(issue)
+    for k, v in scan_results['templates'].items():
+        issue = get_sonarqube_issue(v)
+        issue['ruleId'] = k
+        sonarqube_issues.append(issue)
     sonarqube_report = {
         'issues': sonarqube_issues,
     }
@@ -177,16 +181,12 @@ def main():
                         action='store_true')
     args = parser.parse_args()
     if args.path:
-        show_progress = True
-        if args.json or args.sonarqube:
-            show_progress = False
-
+        is_json = args.json or args.sonarqube
         scan_results = NJSScan(
             args.path,
-            show_progress,
+            is_json,
             args.missing_controls,
         ).scan()
-
         if args.sonarqube:
             sonarqube_output(args.output, scan_results)
         elif args.json:

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -87,7 +87,6 @@ def json_output(outfile, scan_results):
 def sonarqube_output(outfile, scan_results):
     """Sonarqube JSON Output."""
     sonarqube_issues = []
-
     for k, v in scan_results['nodejs'].items():
         issue = get_sonarqube_issue(v)
         issue['ruleId'] = k
@@ -96,13 +95,10 @@ def sonarqube_output(outfile, scan_results):
         issue = get_sonarqube_issue(v)
         issue['ruleId'] = k
         sonarqube_issues.append(issue)
-
     sonarqube_report = {
         'issues': sonarqube_issues,
     }
     json_output(outfile, sonarqube_report)
-    print(json_output)
-    return json_output
 
 
 def get_sonarqube_issue(njsscan_issue):

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -87,40 +87,15 @@ def json_output(outfile, scan_results):
 def sonarqube_output(outfile, scan_results):
     """SonarQube JSON Output."""
     sonarqube_issues = []
-    secondary_locations = []
     for k, v in scan_results['nodejs'].items():
-        issue_data = v['metadata']
-        for ix, file in enumerate(v['files']):
-            text_range = {
-                'startLine': file['match_lines'][0],
-                'endLine': file['match_lines'][1],
-                'startColumn': file['match_position'][0],
-                'endColumn': file['match_position'][1]
-            }
-            location = {
-                'message': issue_data['description'],
-                'filePath': file['file_path'],
-                'textRange': text_range
-            }
-            if ix == 0:
-                primary_location = location
-            else:
-                secondary_locations.append(location)
-        issue = {
-            'engineId': 'njsscan',
-            'ruleId': k,
-            'type': 'VULNERABILITY',
-            'severity': translate_to_sonarqube_severity(issue_data['severity']),
-            'primaryLocation': primary_location,
-        }
-        if secondary_locations:
-            issue['secondaryLocations'] = secondary_locations
+        issue = get_sonarqube_issue(v)
+        issue['ruleId'] = k
         sonarqube_issues.append(issue)
     sonarqube_report = {
         'issues': sonarqube_issues
     }
     if outfile:
-        with open(outfile + '.sonarqube', 'w') as of:
+        with open(outfile, 'w') as of:
             json.dump(sonarqube_report, of, sort_keys=True,
                       indent=2, separators=(',', ': '))
     else:
@@ -128,6 +103,37 @@ def sonarqube_output(outfile, scan_results):
                                   indent=2, separators=(',', ': ')))
         print(json_output)
         return json_output
+
+
+def get_sonarqube_issue(njsscan_issue):
+    secondary_locations = []
+    issue_data = njsscan_issue['metadata']
+    for ix, file in enumerate(njsscan_issue['files']):
+        text_range = {
+            'startLine': file['match_lines'][0],
+            'endLine': file['match_lines'][1],
+            'startColumn': file['match_position'][0],
+            'endColumn': file['match_position'][1]
+        }
+        location = {
+            'message': issue_data['description'],
+            'filePath': file['file_path'],
+            'textRange': text_range
+        }
+        if ix == 0:
+            primary_location = location
+        else:
+            secondary_locations.append(location)
+    issue = {
+        'engineId': 'njsscan',
+        'type': 'VULNERABILITY',
+        'severity': translate_to_sonarqube_severity(issue_data['severity']),
+        'primaryLocation': primary_location,
+    }
+    if secondary_locations:
+        issue['secondaryLocations'] = secondary_locations
+    return issue
+
 
 def translate_to_sonarqube_severity(severity):
     d = {

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -158,7 +158,7 @@ def main():
                         nargs='*',
                         help=('Path can be file(s) or '
                               'directories with source code'))
-    parser.add_argument('-j', '--json',
+    parser.add_argument('--json',
                         help='set output format as JSON',
                         action='store_true')
     parser.add_argument('--sonarqube',

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -87,14 +87,11 @@ def json_output(outfile, scan_results):
 def sonarqube_output(outfile, scan_results):
     """Sonarqube JSON Output."""
     sonarqube_issues = []
-    for k, v in scan_results['nodejs'].items():
-        issue = get_sonarqube_issue(v)
-        issue['ruleId'] = k
-        sonarqube_issues.append(issue)
-    for k, v in scan_results['templates'].items():
-        issue = get_sonarqube_issue(v)
-        issue['ruleId'] = k
-        sonarqube_issues.append(issue)
+    for i in ['nodejs', 'templates']:
+        for k, v in scan_results[i].items():
+            issue = get_sonarqube_issue(v)
+            issue['ruleId'] = k
+            sonarqube_issues.append(issue)
     sonarqube_report = {
         'issues': sonarqube_issues,
     }

--- a/njsscan/__main__.py
+++ b/njsscan/__main__.py
@@ -85,14 +85,14 @@ def json_output(outfile, scan_results):
 
 
 def sonarqube_output(outfile, scan_results):
-    """SonarQube JSON Output."""
+    """Sonarqube JSON Output."""
     sonarqube_issues = []
     for k, v in scan_results['nodejs'].items():
         issue = get_sonarqube_issue(v)
         issue['ruleId'] = k
         sonarqube_issues.append(issue)
     sonarqube_report = {
-        'issues': sonarqube_issues
+        'issues': sonarqube_issues,
     }
     if outfile:
         with open(outfile, 'w') as of:
@@ -113,12 +113,12 @@ def get_sonarqube_issue(njsscan_issue):
             'startLine': file['match_lines'][0],
             'endLine': file['match_lines'][1],
             'startColumn': file['match_position'][0],
-            'endColumn': file['match_position'][1]
+            'endColumn': file['match_position'][1],
         }
         location = {
             'message': issue_data['description'],
             'filePath': file['file_path'],
-            'textRange': text_range
+            'textRange': text_range,
         }
         if ix == 0:
             primary_location = location
@@ -138,9 +138,10 @@ def get_sonarqube_issue(njsscan_issue):
 def translate_to_sonarqube_severity(severity):
     d = {
         'ERROR': 'CRITICAL',
-        'WARNING': 'MAJOR'
+        'WARNING': 'MAJOR',
     }
     return d[severity]
+
 
 def handle_exit(results, exit_warn):
     """Handle Exit."""
@@ -182,7 +183,7 @@ def main():
                         action='store_true',
                         required=False)
     parser.add_argument('-v', '--version',
-                        help="show njsscan version",
+                        help='show njsscan version',
                         required=False,
                         action='store_true')
     args = parser.parse_args()

--- a/njsscan/njsscan.py
+++ b/njsscan/njsscan.py
@@ -22,7 +22,7 @@ class NJSScan:
             'ignore_extensions': conf['ignore_extensions'],
             'ignore_paths': conf['ignore_paths'],
             'ignore_rules': conf['ignore_rules'],
-            'show_progress': json,
+            'show_progress': not json,
         }
         self.paths = paths
         self.result = {

--- a/njsscan/njsscan.py
+++ b/njsscan/njsscan.py
@@ -10,21 +10,15 @@ from njsscan.utils import (
 
 
 class NJSScan:
-    def __init__(self, paths, json, check_controls) -> None:
+    def __init__(self, paths, show_progress, check_controls) -> None:
         conf = get_config(paths)
         self.check_controls = check_controls
-        self.options = {
-            'match_rules': settings.PATTERN_RULES_DIR,
-            'sgrep_rules': settings.SGREP_RULES_DIR,
-            'sgrep_extensions': conf['nodejs_extensions'],
-            'match_extensions': conf['template_extensions'],
-            'ignore_filenames': conf['ignore_filenames'],
-            'ignore_extensions': conf['ignore_extensions'],
-            'ignore_paths': conf['ignore_paths'],
-            'ignore_rules': conf['ignore_rules'],
-        }
-        if not json:
-            self.options['show_progress'] = True
+        self.options = {'match_rules': settings.PATTERN_RULES_DIR, 'sgrep_rules': settings.SGREP_RULES_DIR,
+                        'sgrep_extensions': conf['nodejs_extensions'], 'match_extensions': conf['template_extensions'],
+                        'ignore_filenames': conf['ignore_filenames'], 'ignore_extensions': conf['ignore_extensions'],
+                        'ignore_paths': conf['ignore_paths'], 'ignore_rules': conf['ignore_rules'],
+                        'show_progress': show_progress}
+
         self.paths = paths
         self.result = {
             'templates': {},

--- a/njsscan/njsscan.py
+++ b/njsscan/njsscan.py
@@ -13,12 +13,17 @@ class NJSScan:
     def __init__(self, paths, show_progress, check_controls) -> None:
         conf = get_config(paths)
         self.check_controls = check_controls
-        self.options = {'match_rules': settings.PATTERN_RULES_DIR, 'sgrep_rules': settings.SGREP_RULES_DIR,
-                        'sgrep_extensions': conf['nodejs_extensions'], 'match_extensions': conf['template_extensions'],
-                        'ignore_filenames': conf['ignore_filenames'], 'ignore_extensions': conf['ignore_extensions'],
-                        'ignore_paths': conf['ignore_paths'], 'ignore_rules': conf['ignore_rules'],
-                        'show_progress': show_progress}
-
+        self.options = {
+            'match_rules': settings.PATTERN_RULES_DIR,
+            'sgrep_rules': settings.SGREP_RULES_DIR,
+            'sgrep_extensions': conf['nodejs_extensions'],
+            'match_extensions': conf['template_extensions'],
+            'ignore_filenames': conf['ignore_filenames'],
+            'ignore_extensions': conf['ignore_extensions'],
+            'ignore_paths': conf['ignore_paths'],
+            'ignore_rules': conf['ignore_rules'],
+            'show_progress': show_progress,
+        }
         self.paths = paths
         self.result = {
             'templates': {},

--- a/njsscan/njsscan.py
+++ b/njsscan/njsscan.py
@@ -10,7 +10,7 @@ from njsscan.utils import (
 
 
 class NJSScan:
-    def __init__(self, paths, show_progress, check_controls) -> None:
+    def __init__(self, paths, json, check_controls) -> None:
         conf = get_config(paths)
         self.check_controls = check_controls
         self.options = {
@@ -22,7 +22,7 @@ class NJSScan:
             'ignore_extensions': conf['ignore_extensions'],
             'ignore_paths': conf['ignore_paths'],
             'ignore_rules': conf['ignore_rules'],
-            'show_progress': show_progress,
+            'show_progress': json,
         }
         self.paths = paths
         self.result = {

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_version(rel_path):
 
 
 description = ('njsscan is a SAST tool that can find insecure code'
-               ' patterns in your Node.js applications. Is it the real life?')
+               ' patterns in your Node.js applications.')
 setup(
     name='njsscan',
     version=get_version('njsscan/__init__.py'),

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_version(rel_path):
 
 
 description = ('njsscan is a SAST tool that can find insecure code'
-               ' patterns in your Node.js applications.')
+               ' patterns in your Node.js applications. Is it the real life?')
 setup(
     name='njsscan',
     version=get_version('njsscan/__init__.py'),


### PR DESCRIPTION
This PR adds the feature of generating a Sonarqube compatible report. To use it, simply add the `--sonarqube` flag when running the CLI.

Further instructions on how to import the report to SonarQube and the formatting of the issues can be found [here](https://docs.sonarqube.org/latest/analysis/generic-issue/).