### PR TITLE
Speed up contrib.nodejsscan.jwt_exposed_data.jwt_exposed_data

### DIFF
--- a/njsscan/rules/semantic_grep/jwt/jwt_exposed_data.yaml
+++ b/njsscan/rules/semantic_grep/jwt/jwt_exposed_data.yaml
@@ -2,7 +2,6 @@ rules:
   - id: jwt_exposed_data
     patterns:
       - pattern-inside: |
-          ...
           require('jose')
           ...
       - pattern-either:


### PR DESCRIPTION
Removing a leading statement ellipsis trims time on a test corpus from
32.7 to 24.2 seconds.