### PR TITLE
add severity-filter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ A `.njsscan` file in the root of the source code directory allows you to configu
   - regex_injection_dos
   - pug_jade_template
 
+  severity-filter:
+  - WARNING
+  - ERROR
 ```
 
 ## Suppress Findings

--- a/njsscan/njsscan.py
+++ b/njsscan/njsscan.py
@@ -27,6 +27,7 @@ class NJSScan:
             'ignore_extensions': conf['ignore_extensions'],
             'ignore_paths': conf['ignore_paths'],
             'ignore_rules': conf['ignore_rules'],
+            'severity_filter': conf['severity_filter'],
             'show_progress': not json,
         }
         self.paths = paths
@@ -50,6 +51,7 @@ class NJSScan:
         self.format_sgrep(results['semantic_grep'])
         self.format_matches(results['pattern_matcher'])
         self.post_ignore_rules()
+        self.post_ignore_rules_by_severity()
         self.post_ignore_files()
 
     def missing_controls(self, result):
@@ -100,6 +102,17 @@ class NJSScan:
                 del self.result['nodejs'][rule_id]
             if rule_id in self.result['templates']:
                 del self.result['templates'][rule_id]
+
+    def post_ignore_rules_by_severity(self):
+        """Filter findings by rule severity."""
+        del_keys = set()
+        for rule_id, details in self.result['nodejs'].items():
+            issue_severity = details.get('metadata').get('severity')
+            if issue_severity not in self.options['severity_filter']:
+                del_keys.add(rule_id)
+        for rid in del_keys:
+            if rid in self.result['nodejs']:
+                del self.result['nodejs'][rid]
 
     def suppress_pm_comments(self, obj, rule_id):
         """Suppress pattern matcher."""

--- a/njsscan/njsscan.py
+++ b/njsscan/njsscan.py
@@ -51,7 +51,8 @@ class NJSScan:
         self.format_sgrep(results['semantic_grep'])
         self.format_matches(results['pattern_matcher'])
         self.post_ignore_rules()
-        self.post_ignore_rules_by_severity()
+        self.post_ignore_rules_by_severity('nodejs')
+        self.post_ignore_rules_by_severity('template')
         self.post_ignore_files()
 
     def missing_controls(self, result):
@@ -103,16 +104,18 @@ class NJSScan:
             if rule_id in self.result['templates']:
                 del self.result['templates'][rule_id]
 
-    def post_ignore_rules_by_severity(self):
+    def post_ignore_rules_by_severity(self, key):
         """Filter findings by rule severity."""
         del_keys = set()
-        for rule_id, details in self.result['nodejs'].items():
+        if key not in self.result:
+            return
+        for rule_id, details in self.result[key].items():
             issue_severity = details.get('metadata').get('severity')
             if issue_severity not in self.options['severity_filter']:
                 del_keys.add(rule_id)
         for rid in del_keys:
-            if rid in self.result['nodejs']:
-                del self.result['nodejs'][rid]
+            if rid in self.result[key]:
+                del self.result[key][rid]
 
     def suppress_pm_comments(self, obj, rule_id):
         """Suppress pattern matcher."""

--- a/njsscan/settings.py
+++ b/njsscan/settings.py
@@ -64,3 +64,9 @@ GOOD_CONTROLS_ID = {
     'helmet_header_xss_filter',
     'helmet_header_check_crossdomain',
 }
+
+SEVERITY_FILTER = (
+    'INFO',
+    'WARNING',
+    'ERROR',
+)

--- a/njsscan/utils.py
+++ b/njsscan/utils.py
@@ -19,6 +19,7 @@ def get_config(base_path, config_file):
         'ignore_extensions': config.IGNORE_EXTENSIONS,
         'ignore_paths': config.IGNORE_PATHS,
         'ignore_rules': set(),
+        'severity_filter': config.SEVERITY_FILTER,
     }
     if config_file:
         cfile = Path(config_file)
@@ -36,6 +37,7 @@ def get_config(base_path, config_file):
         usr_igonre_paths = root.get('ignore-paths')
         usr_ignore_exts = root.get('ignore-extensions')
         usr_ignore_rules = root.get('ignore-rules')
+        usr_severity_filter = root.get('severity-filter')
         if usr_njs_ext:
             options['nodejs_extensions'].update(usr_njs_ext)
         if usr_tmpl_ext:
@@ -48,6 +50,8 @@ def get_config(base_path, config_file):
             options['ignore_extensions'].update(usr_ignore_exts)
         if usr_ignore_rules:
             options['ignore_rules'].update(usr_ignore_rules)
+        if usr_severity_filter:
+            options['severity_filter'] = usr_severity_filter
     return options
 
 


### PR DESCRIPTION
Resolve https://github.com/ajinabraham/njsscan/issues/69

Running scan without `.njsscan` file:
```
❯ docker run -v $(pwd):/app njsscan /app --json | jq '.nodejs[].metadata.severity'
"INFO"
"INFO"
"WARNING"
"INFO"
"INFO"
"WARNING"
"WARNING"
"WARNING"
"WARNING"
"ERROR"
"ERROR"
"ERROR"
"WARNING"
"ERROR"
```

Add `.njsscan` file with content:
```
---
- severity-filter:
  - ERROR
  - WARNING
```

And got only `WARNING` and `ERROR` results:
```
❯ docker run -v $(pwd):/app njsscan /app --json | jq '.nodejs[].metadata.severity'
"WARNING"
"WARNING"
"WARNING"
"WARNING"
"WARNING"
"ERROR"
"ERROR"
"ERROR"
"WARNING"
"ERROR"
```
