### PR TITLE
Update nosql_find_injection.yaml to exclude sequelize's .findOne() false positives

### DIFF
--- a/njsscan/rules/semantic_grep/database/nosql_find_injection.yaml
+++ b/njsscan/rules/semantic_grep/database/nosql_find_injection.yaml
@@ -2,6 +2,16 @@ rules:
 - id: node_nosqli_injection
   patterns:
   - pattern-not-inside: |
+      $SEQUELIZE = require('sequelize')
+      ...
+      $SEQUELIZE(...)
+      ...
+  - pattern-not-inside: |
+      import $SEQUELIZE from 'sequelize'
+      ...
+      $SEQUELIZE(...)
+      ...
+  - pattern-not-inside: |
       $SANITIZE = require('mongo-sanitize')
       ...
       $SANITIZE(...)


### PR DESCRIPTION
Related to issue 114: https://github.com/ajinabraham/njsscan/issues/114

A possible fix is to include `require('sequelize')` (for Node.js) or `import ... from 'sequelize'` (for ES6) into the `pattern-not-inside` check.

This will rule out false positives triggered by Sequelize's `.findOne()` function ([docs](https://sequelize.org/docs/v6/core-concepts/model-querying-finders/#findone)), which is identical in syntax but different in functionality from MongoDB's `.findOne()`.