### PR TITLE
Exclude hugo specific safe* keyword from squirrelly analysis

### DIFF
--- a/njsscan/rules/pattern_matcher/template_rules.yaml
+++ b/njsscan/rules/pattern_matcher/template_rules.yaml
@@ -76,6 +76,18 @@
     cwe: cwe-79
     owasp-web: a1
 
+- id: hugo_template
+  message: The Hugo framework has an unescaped variable. Untrusted user input
+    passed to this variable results in Cross Site Scripting (XSS). 
+    It may be worth adding that Hugo is a static site generator with no concept of dynamic user input.
+  type: Regex
+  pattern: '{{.+\|.*(?:safeURL|safeHTML|safeCSS|safeJS|safeJSStr|safeHTMLAttr).*}}'
+  severity: WARNING
+  input_case: exact
+  metadata:
+    cwe: cwe-79
+    owasp-web: a1
+
 - id: electronjs_node_integration
   message: Node integration exposes node.js APIs to the electron app and this
     can introduce remote code execution vulnerabilities to the application if the

--- a/njsscan/rules/pattern_matcher/template_rules.yaml
+++ b/njsscan/rules/pattern_matcher/template_rules.yaml
@@ -69,7 +69,7 @@
   message: The Squirrelly.js template has an unescaped variable. Untrusted user input
     passed to this variable results in Cross Site Scripting (XSS)
   type: Regex
-  pattern: '{{.+\|.*safe.*}}'
+  pattern: '{{(?!.*(?:safeURL|safeHTML|safeCSS|safeJS|safeJSStr|safeHTMLAttr)).*\|.*safe.*}}'
   severity: ERROR
   input_case: exact
   metadata:

--- a/tests/assets/templates/true_negatives/hugo.html
+++ b/tests/assets/templates/true_negatives/hugo.html
@@ -1,0 +1,3 @@
+<ul>
+    <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+</ul>

--- a/tests/assets/templates/true_positives/hugo.html
+++ b/tests/assets/templates/true_positives/hugo.html
@@ -1,0 +1,3 @@
+<ul>
+    <li><a href="{{ .URL | safeHTML }}">{{ .Name }}</a></li>
+</ul>


### PR DESCRIPTION
The `squirrelly_template` regex produces false positives on Hugo projects code-based.  

The regex excludes keywords: safeURL/safeHTML/safeJS/ ... https://gohugo.io/functions/safe/