### PR TITLE
feat(rules): detect DOM text reinterpreted as HTML

### DIFF
--- a/njsscan/rules/semantic_grep/xss/xss_dom.yaml
+++ b/njsscan/rules/semantic_grep/xss/xss_dom.yaml
@@ -1,0 +1,38 @@
+rules:
+  - id: dom_xss
+    mode: taint
+    pattern-sources:
+      - pattern: document.location.$PROP
+      - pattern: location.hash
+      - pattern: location.search
+      - pattern: document.URL
+      - pattern: document.documentURI
+      - pattern: document.referrer
+      - pattern: window.name
+      - pattern: $EL.textContent
+      - pattern: $EL.innerText
+      - pattern: $EL.getAttribute(...)
+    pattern-sanitizers:
+      - pattern: DOMPurify.sanitize(...)
+      - pattern: sanitizeHtml(...)
+      - pattern: encodeURIComponent(...)
+      - pattern: $X.escapeHtml(...)
+    pattern-sinks:
+      - pattern: $EL.innerHTML = $SINK
+      - pattern: $EL.outerHTML = $SINK
+      - pattern: $EL.insertAdjacentHTML($POS, $SINK)
+      - pattern: document.write($SINK)
+      - pattern: document.writeln($SINK)
+      - pattern: $EL.html($SINK)
+    message: >-
+      DOM-derived text is written back to the page as HTML. The value read from
+      the DOM (or the URL) reaches an HTML interpretation sink such as innerHTML,
+      outerHTML, insertAdjacentHTML or document.write, which results in DOM Cross
+      Site Scripting. Sanitize the value with DOMPurify.sanitize() before writing
+      it, or assign it with textContent so that it is never parsed as HTML.
+    languages:
+      - javascript
+    severity: ERROR
+    metadata:
+      owasp-web: a3
+      cwe: cwe-79

--- a/tests/assets/node_source/true_negatives/safe_xss_dom.js
+++ b/tests/assets/node_source/true_negatives/safe_xss_dom.js
@@ -1,0 +1,20 @@
+// The same DOM values, written safely.
+
+function renderFragment() {
+    const raw = location.hash;
+    document.getElementById('out').textContent = raw;
+}
+
+function renderNote(node) {
+    const note = node.textContent;
+    document.querySelector('#note').innerHTML = DOMPurify.sanitize('<b>' + note + '</b>');
+}
+
+function renderTitle(input) {
+    const title = input.getAttribute('data-title');
+    document.getElementById('title').insertAdjacentHTML('beforeend', sanitizeHtml(title));
+}
+
+function renderStatic() {
+    document.write('<p>static markup</p>');
+}

--- a/tests/assets/node_source/true_positives/semantic_grep/xss/xss_dom.js
+++ b/tests/assets/node_source/true_positives/semantic_grep/xss/xss_dom.js
@@ -1,0 +1,21 @@
+// DOM text read back into the page as HTML - DOM XSS.
+
+function renderFragment() {
+    const raw = location.hash;
+    document.getElementById('out').innerHTML = raw;
+}
+
+function renderNote(node) {
+    const note = node.textContent;
+    const wrapper = '<b>' + note + '</b>';
+    document.querySelector('#note').outerHTML = wrapper;
+}
+
+function renderTitle(input) {
+    const title = input.getAttribute('data-title');
+    document.getElementById('title').insertAdjacentHTML('beforeend', title);
+}
+
+function renderReferrer() {
+    document.write(document.referrer);
+}

--- a/tests/unit/test_nodejs.py
+++ b/tests/unit/test_nodejs.py
@@ -95,6 +95,7 @@ TRIGGERED = {
     'jwt_not_revoked': 5,
     'buffer_noassert': 1,
     'xss_disable_mustache_escape': 1,
+    'dom_xss': 4,
     'join_resolve_path_traversal': 4,
     'eval_require': 4,
     'cookie_session_default': 1,


### PR DESCRIPTION
Fixes #129

Adds a taint rule for the DOM-text → HTML flow described in the issue: a value read from the DOM or the
URL travels through intermediate variables and is then written back as markup.

`njsscan/rules/semantic_grep/xss/xss_dom.yaml` (`dom_xss`):

- **sources** — `location.hash`, `location.search`, `document.URL`, `document.documentURI`,
  `document.location.*`, `document.referrer`, `window.name`, `$EL.textContent`, `$EL.innerText`,
  `$EL.getAttribute(...)`
- **sinks** — `innerHTML`, `outerHTML`, `insertAdjacentHTML(...)`, `document.write/writeln`, `$EL.html(...)`
- **sanitizers** — `DOMPurify.sanitize(...)`, `sanitizeHtml(...)`, `encodeURIComponent(...)`, `*.escapeHtml(...)`

Semgrep's `mode: taint` handles the propagation, so the intermediate assignment and string concatenation
in the issue's example are covered without enumerating shapes.

I deliberately left `$EL.value` out of the sources for now: it matches any `.value` read, including
non-DOM objects, and I could not convince myself it stays FP-free outside this test corpus. Happy to add
it if you'd rather have the coverage.

### Test assets

- `tests/assets/node_source/true_positives/semantic_grep/xss/xss_dom.js` — four flows: fragment →
  `innerHTML`, `textContent` → concatenation → `outerHTML`, `getAttribute` → `insertAdjacentHTML`,
  `document.referrer` → `document.write`
- `tests/assets/node_source/true_negatives/safe_xss_dom.js` — the same four values written safely
  (`textContent`, `DOMPurify.sanitize`, `sanitizeHtml`, a static string), keeping the positive/negative
  file counts equal as `test_nodejs_rules` requires
- `'dom_xss': 4` added to `TRIGGERED`

### Verified (semgrep 1.x container)

```
new true-positive file          ->  4 findings
all 65 true-negative files      ->  0 findings
all 64 other true-positive files->  0 findings
```

The last two runs are the ones that matter for regressions: the rule adds no findings anywhere else in
the corpus, so existing per-rule counts are unchanged.

AI-assisted (LLM used for drafting); the rule, the assets and the runs above are mine.
